### PR TITLE
Fix: null sorting of multiple sort keys.

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -571,6 +571,7 @@ GARROW_AVAILABLE_IN_3_0
 GArrowSortKey *
 garrow_sort_key_new(const gchar *target,
                     GArrowSortOrder order,
+                    GArrowNullPlacement null_placement,
                     GError **error);
 
 GARROW_AVAILABLE_IN_3_0

--- a/cpp/src/arrow/acero/order_by_node.cc
+++ b/cpp/src/arrow/acero/order_by_node.cc
@@ -115,7 +115,7 @@ class OrderByNode : public ExecNode, public TracedNode {
     ARROW_ASSIGN_OR_RAISE(
         auto table,
         Table::FromRecordBatches(output_schema_, std::move(accumulation_queue_)));
-    SortOptions sort_options(ordering_.sort_keys(), ordering_.null_placement());
+    SortOptions sort_options(ordering_.sort_keys());
     ExecContext* ctx = plan_->query_context()->exec_context();
     ARROW_ASSIGN_OR_RAISE(auto indices, SortIndices(table, sort_options, ctx));
     ARROW_ASSIGN_OR_RAISE(Datum sorted,

--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -515,7 +515,7 @@ TEST(ExecPlan, ToString) {
   });
   ASSERT_OK_AND_ASSIGN(std::string plan_str, DeclarationToString(declaration));
   EXPECT_EQ(plan_str, R"a(ExecPlan with 6 nodes:
-custom_sink_label:OrderBySinkNode{by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC], null_placement=AtEnd}}
+custom_sink_label:OrderBySinkNode{by={sort_keys=[FieldRef.Name(sum(multiply(i32, 2))) ASC AtEnd]}}
   :FilterNode{filter=(sum(multiply(i32, 2)) > 10)}
     :GroupByNode{keys=["bool"], aggregates=[
     	hash_sum(multiply(i32, 2)),

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -135,9 +135,8 @@ static auto kRunEndEncodeOptionsType = GetFunctionOptionsType<RunEndEncodeOption
 static auto kArraySortOptionsType = GetFunctionOptionsType<ArraySortOptions>(
     DataMember("order", &ArraySortOptions::order),
     DataMember("null_placement", &ArraySortOptions::null_placement));
-static auto kSortOptionsType = GetFunctionOptionsType<SortOptions>(
-    DataMember("sort_keys", &SortOptions::sort_keys),
-    DataMember("null_placement", &SortOptions::null_placement));
+static auto kSortOptionsType =
+    GetFunctionOptionsType<SortOptions>(DataMember("sort_keys", &SortOptions::sort_keys));
 static auto kPartitionNthOptionsType = GetFunctionOptionsType<PartitionNthOptions>(
     DataMember("pivot", &PartitionNthOptions::pivot),
     DataMember("null_placement", &PartitionNthOptions::null_placement));
@@ -180,14 +179,10 @@ ArraySortOptions::ArraySortOptions(SortOrder order, NullPlacement null_placement
       null_placement(null_placement) {}
 constexpr char ArraySortOptions::kTypeName[];
 
-SortOptions::SortOptions(std::vector<SortKey> sort_keys, NullPlacement null_placement)
-    : FunctionOptions(internal::kSortOptionsType),
-      sort_keys(std::move(sort_keys)),
-      null_placement(null_placement) {}
+SortOptions::SortOptions(std::vector<SortKey> sort_keys)
+    : FunctionOptions(internal::kSortOptionsType), sort_keys(std::move(sort_keys)) {}
 SortOptions::SortOptions(const Ordering& ordering)
-    : FunctionOptions(internal::kSortOptionsType),
-      sort_keys(ordering.sort_keys()),
-      null_placement(ordering.null_placement()) {}
+    : FunctionOptions(internal::kSortOptionsType), sort_keys(ordering.sort_keys()) {}
 constexpr char SortOptions::kTypeName[];
 
 PartitionNthOptions::PartitionNthOptions(int64_t pivot, NullPlacement null_placement)
@@ -299,7 +294,7 @@ Result<std::shared_ptr<Array>> SortIndices(const Array& values, SortOrder order,
 Result<std::shared_ptr<Array>> SortIndices(const ChunkedArray& chunked_array,
                                            const ArraySortOptions& array_options,
                                            ExecContext* ctx) {
-  SortOptions options({SortKey("", array_options.order)}, array_options.null_placement);
+  SortOptions options({SortKey("", array_options.order, array_options.null_placement)});
   ARROW_ASSIGN_OR_RAISE(
       Datum result, CallFunction("sort_indices", {Datum(chunked_array)}, &options, ctx));
   return result.make_array();

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -105,8 +105,7 @@ class ARROW_EXPORT ArraySortOptions : public FunctionOptions {
 
 class ARROW_EXPORT SortOptions : public FunctionOptions {
  public:
-  explicit SortOptions(std::vector<SortKey> sort_keys = {},
-                       NullPlacement null_placement = NullPlacement::AtEnd);
+  explicit SortOptions(std::vector<SortKey> sort_keys = {});
   explicit SortOptions(const Ordering& ordering);
   static constexpr char const kTypeName[] = "SortOptions";
   static SortOptions Defaults() { return SortOptions(); }
@@ -115,13 +114,11 @@ class ARROW_EXPORT SortOptions : public FunctionOptions {
   /// Note: Both classes contain the exact same information.  However,
   /// sort_options should only be used in a "function options" context while Ordering
   /// is used more generally.
-  Ordering AsOrdering() && { return Ordering(std::move(sort_keys), null_placement); }
-  Ordering AsOrdering() const& { return Ordering(sort_keys, null_placement); }
+  Ordering AsOrdering() && { return Ordering(std::move(sort_keys)); }
+  Ordering AsOrdering() const& { return Ordering(sort_keys); }
 
   /// Column key(s) to order by and how to order by these sort keys.
   std::vector<SortKey> sort_keys;
-  /// Whether nulls and NaNs are placed at the start or at the end
-  NullPlacement null_placement;
 };
 
 /// \brief SelectK options

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -1400,7 +1400,7 @@ TEST(Ordering, IsSuborderOf) {
   Ordering a{{SortKey{3}, SortKey{1}, SortKey{7}}};
   Ordering b{{SortKey{3}, SortKey{1}}};
   Ordering c{{SortKey{1}, SortKey{7}}};
-  Ordering d{{SortKey{1}, SortKey{7}}, NullPlacement::AtEnd};
+  Ordering d{{SortKey{1}, SortKey{7, NullPlacement::AtStart}}};
   Ordering imp = Ordering::Implicit();
   Ordering unordered = Ordering::Unordered();
 

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -402,7 +402,7 @@ class RadixRecordBatchSorter {
         : physical_type(sort_key.type),
           array(sort_key.owned_array),
           order(sort_key.order),
-          null_placement(options.null_placement),
+          null_placement(sort_key.null_placement),
           next_column(next_column) {}
 
     Result<std::unique_ptr<RecordBatchColumnSorter>> MakeColumnSort() {
@@ -462,16 +462,14 @@ class MultipleKeyRecordBatchSorter : public TypeVisitor {
       : indices_begin_(indices_begin),
         indices_end_(indices_end),
         sort_keys_(std::move(sort_keys)),
-        null_placement_(options.null_placement),
-        comparator_(sort_keys_, null_placement_) {}
+        comparator_(sort_keys_) {}
 
   MultipleKeyRecordBatchSorter(uint64_t* indices_begin, uint64_t* indices_end,
                                const RecordBatch& batch, const SortOptions& options)
       : indices_begin_(indices_begin),
         indices_end_(indices_end),
         sort_keys_(ResolveSortKeys(batch, options.sort_keys, &status_)),
-        null_placement_(options.null_placement),
-        comparator_(sort_keys_, null_placement_) {}
+        comparator_(sort_keys_) {}
 
   // This is optimized for the first sort key. The first sort key sort
   // is processed in this class. The second and following sort keys
@@ -552,10 +550,10 @@ class MultipleKeyRecordBatchSorter : public TypeVisitor {
     const ArrayType& array =
         ::arrow::internal::checked_cast<const ArrayType&>(first_sort_key.array);
 
-    const auto p = PartitionNullsOnly<StablePartitioner>(indices_begin_, indices_end_,
-                                                         array, 0, null_placement_);
+    const auto p = PartitionNullsOnly<StablePartitioner>(
+        indices_begin_, indices_end_, array, 0, first_sort_key.null_placement);
     const auto q = PartitionNullLikes<ArrayType, StablePartitioner>(
-        p.non_nulls_begin, p.non_nulls_end, array, 0, null_placement_);
+        p.non_nulls_begin, p.non_nulls_end, array, 0, first_sort_key.null_placement);
 
     auto& comparator = comparator_;
     if (q.nulls_begin != q.nulls_end) {
@@ -583,7 +581,6 @@ class MultipleKeyRecordBatchSorter : public TypeVisitor {
   uint64_t* indices_end_;
   Status status_;
   std::vector<ResolvedSortKey> sort_keys_;
-  NullPlacement null_placement_;
   Comparator comparator_;
 };
 
@@ -607,13 +604,12 @@ class TableSorter {
         table_(table),
         batches_(MakeBatches(table, &status_)),
         options_(options),
-        null_placement_(options.null_placement),
         left_resolver_(batches_),
         right_resolver_(batches_),
         sort_keys_(ResolveSortKeys(table, batches_, options.sort_keys, &status_)),
         indices_begin_(indices_begin),
         indices_end_(indices_end),
-        comparator_(sort_keys_, null_placement_) {}
+        comparator_(sort_keys_) {}
 
   // This is optimized for null partitioning and merging along the first sort key.
   // Other sort keys are delegated to the Comparator class.
@@ -711,7 +707,7 @@ class TableSorter {
       MergeNonNulls<Type>(range_begin, range_middle, range_end, temp_indices);
     };
 
-    MergeImpl merge_impl(options_.null_placement, std::move(merge_nulls),
+    MergeImpl merge_impl(sort_keys_[0].null_placement, std::move(merge_nulls),
                          std::move(merge_non_nulls));
     RETURN_NOT_OK(merge_impl.Init(ctx_, table_.num_rows()));
 
@@ -758,7 +754,7 @@ class TableSorter {
                  const auto right_is_null = chunk_right.IsNull();
                  if (left_is_null == right_is_null) {
                    return comparator.Compare(left_loc, right_loc, 1);
-                 } else if (options_.null_placement == NullPlacement::AtEnd) {
+                 } else if (first_sort_key.null_placement == NullPlacement::AtEnd) {
                    return right_is_null;
                  } else {
                    return left_is_null;
@@ -847,7 +843,6 @@ class TableSorter {
   const Table& table_;
   const RecordBatchVector batches_;
   const SortOptions& options_;
-  const NullPlacement null_placement_;
   const ::arrow::internal::ChunkResolver left_resolver_, right_resolver_;
   const std::vector<ResolvedSortKey> sort_keys_;
   uint64_t* indices_begin_;
@@ -936,18 +931,22 @@ class SortIndicesMetaFunction : public MetaFunction {
   Result<Datum> SortIndices(const Array& values, const SortOptions& options,
                             ExecContext* ctx) const {
     SortOrder order = SortOrder::Ascending;
+    NullPlacement null_placement = NullPlacement::AtEnd;
     if (!options.sort_keys.empty()) {
       order = options.sort_keys[0].order;
+      null_placement = options.sort_keys[0].null_placement;
     }
-    ArraySortOptions array_options(order, options.null_placement);
+    ArraySortOptions array_options(order, null_placement);
     return CallFunction("array_sort_indices", {values}, &array_options, ctx);
   }
 
   Result<Datum> SortIndices(const ChunkedArray& chunked_array, const SortOptions& options,
                             ExecContext* ctx) const {
     SortOrder order = SortOrder::Ascending;
+    NullPlacement null_placement = NullPlacement::AtEnd;
     if (!options.sort_keys.empty()) {
       order = options.sort_keys[0].order;
+      null_placement = options.sort_keys[0].null_placement;
     }
 
     auto out_type = uint64();
@@ -962,8 +961,8 @@ class SortIndicesMetaFunction : public MetaFunction {
     auto out_end = out_begin + length;
     std::iota(out_begin, out_end, 0);
 
-    RETURN_NOT_OK(SortChunkedArray(ctx, out_begin, out_end, chunked_array, order,
-                                   options.null_placement));
+    RETURN_NOT_OK(
+        SortChunkedArray(ctx, out_begin, out_end, chunked_array, order, null_placement));
     return Datum(out);
   }
 
@@ -1056,7 +1055,7 @@ struct SortFieldPopulator {
                             PrependInvalidColumn(sort_key.target.FindOne(schema)));
       if (seen_.insert(match).second) {
         ARROW_ASSIGN_OR_RAISE(auto schema_field, match.Get(schema));
-        AddField(*schema_field->type(), match, sort_key.order);
+        AddField(*schema_field->type(), match, sort_key.order, sort_key.null_placement);
       }
     }
 
@@ -1064,7 +1063,7 @@ struct SortFieldPopulator {
   }
 
  protected:
-  void AddLeafFields(const FieldVector& fields, SortOrder order) {
+  void AddLeafFields(const FieldVector& fields, SortOrder order, NullPlacement null_placement) {
     if (fields.empty()) {
       return;
     }
@@ -1073,21 +1072,21 @@ struct SortFieldPopulator {
     for (const auto& f : fields) {
       const auto& type = *f->type();
       if (type.id() == Type::STRUCT) {
-        AddLeafFields(type.fields(), order);
+        AddLeafFields(type.fields(), order, null_placement);
       } else {
-        sort_fields_.emplace_back(FieldPath(tmp_indices_), order, &type);
+        sort_fields_.emplace_back(FieldPath(tmp_indices_), order, &type, null_placement);
       }
       ++tmp_indices_.back();
     }
     tmp_indices_.pop_back();
   }
 
-  void AddField(const DataType& type, const FieldPath& path, SortOrder order) {
+  void AddField(const DataType& type, const FieldPath& path, SortOrder order, NullPlacement null_placement) {
     if (type.id() == Type::STRUCT) {
       tmp_indices_ = path.indices();
-      AddLeafFields(type.fields(), order);
+      AddLeafFields(type.fields(), order, null_placement);
     } else {
-      sort_fields_.emplace_back(path, order, &type);
+      sort_fields_.emplace_back(path, order, &type, null_placement);
     }
   }
 
@@ -1135,10 +1134,9 @@ Result<NullPartitionResult> SortStructArray(ExecContext* ctx, uint64_t* indices_
                                  std::move(columns));
 
   auto options = SortOptions::Defaults();
-  options.null_placement = null_placement;
   options.sort_keys.reserve(array.num_fields());
   for (int i = 0; i < array.num_fields(); ++i) {
-    options.sort_keys.push_back(SortKey(FieldRef(i), sort_order));
+    options.sort_keys.push_back(SortKey(FieldRef(i), sort_order, null_placement));
   }
 
   ARROW_ASSIGN_OR_RAISE(auto sort_keys,

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -475,16 +475,19 @@ Result<NullPartitionResult> SortStructArray(ExecContext* ctx, uint64_t* indices_
 
 struct SortField {
   SortField() = default;
-  SortField(FieldPath path, SortOrder order, const DataType* type)
-      : path(std::move(path)), order(order), type(type) {}
-  SortField(int index, SortOrder order, const DataType* type)
-      : SortField(FieldPath({index}), order, type) {}
+  SortField(FieldPath path, SortOrder order, const DataType* type,
+            NullPlacement null_placement)
+      : path(std::move(path)), order(order), type(type), null_placement(null_placement) {}
+  SortField(int index, SortOrder order, const DataType* type,
+            NullPlacement null_placement)
+      : SortField(FieldPath({index}), order, type, null_placement) {}
 
   bool is_nested() const { return path.indices().size() > 1; }
 
   FieldPath path;
   SortOrder order;
   const DataType* type;
+  NullPlacement null_placement;
 };
 
 inline Status CheckNonNested(const FieldRef& ref) {
@@ -530,9 +533,9 @@ Result<std::vector<ResolvedSortKey>> ResolveSortKeys(
           // paths [0,0,0,0] and [0,0,0,1], we shouldn't need to flatten the first three
           // components more than once.
           ARROW_ASSIGN_OR_RAISE(auto child, f.path.GetFlattened(table_or_batch));
-          return ResolvedSortKey{std::move(child), f.order};
+          return ResolvedSortKey{std::move(child), f.order, f.null_placement};
         }
-        return ResolvedSortKey{table_or_batch.column(f.path[0]), f.order};
+        return ResolvedSortKey{table_or_batch.column(f.path[0]), f.order, f.null_placement};
       });
 }
 
@@ -582,15 +585,13 @@ template <typename ResolvedSortKey>
 struct ColumnComparator {
   using Location = typename ResolvedSortKey::LocationType;
 
-  ColumnComparator(const ResolvedSortKey& sort_key, NullPlacement null_placement)
-      : sort_key_(sort_key), null_placement_(null_placement) {}
+  ColumnComparator(const ResolvedSortKey& sort_key) : sort_key_(sort_key) {}
 
   virtual ~ColumnComparator() = default;
 
   virtual int Compare(const Location& left, const Location& right) const = 0;
 
   ResolvedSortKey sort_key_;
-  NullPlacement null_placement_;
 };
 
 template <typename ResolvedSortKey, typename Type>
@@ -611,13 +612,13 @@ struct ConcreteColumnComparator : public ColumnComparator<ResolvedSortKey> {
       if (is_null_left && is_null_right) {
         return 0;
       } else if (is_null_left) {
-        return this->null_placement_ == NullPlacement::AtStart ? -1 : 1;
+        return sort_key.null_placement == NullPlacement::AtStart ? -1 : 1;
       } else if (is_null_right) {
-        return this->null_placement_ == NullPlacement::AtStart ? 1 : -1;
+        return sort_key.null_placement == NullPlacement::AtStart ? 1 : -1;
       }
     }
     return CompareTypeValues<Type>(chunk_left.Value(), chunk_right.Value(),
-                                   sort_key.order, this->null_placement_);
+                                   sort_key.order, sort_key.null_placement);
   }
 };
 
@@ -638,9 +639,8 @@ class MultipleKeyComparator {
  public:
   using Location = typename ResolvedSortKey::LocationType;
 
-  MultipleKeyComparator(const std::vector<ResolvedSortKey>& sort_keys,
-                        NullPlacement null_placement)
-      : sort_keys_(sort_keys), null_placement_(null_placement) {
+  MultipleKeyComparator(const std::vector<ResolvedSortKey>& sort_keys)
+      : sort_keys_(sort_keys) {
     status_ &= MakeComparators();
   }
 
@@ -675,12 +675,11 @@ class MultipleKeyComparator {
     template <typename Type>
     Status VisitGeneric(const Type& type) {
       res.reset(
-          new ConcreteColumnComparator<ResolvedSortKey, Type>{sort_key, null_placement});
+          new ConcreteColumnComparator<ResolvedSortKey, Type>{sort_key});
       return Status::OK();
     }
 
     const ResolvedSortKey& sort_key;
-    NullPlacement null_placement;
     std::unique_ptr<ColumnComparator<ResolvedSortKey>> res;
   };
 
@@ -688,7 +687,7 @@ class MultipleKeyComparator {
     column_comparators_.reserve(sort_keys_.size());
 
     for (const auto& sort_key : sort_keys_) {
-      ColumnComparatorFactory factory{sort_key, null_placement_, nullptr};
+      ColumnComparatorFactory factory{sort_key, nullptr};
       RETURN_NOT_OK(VisitTypeInline(*sort_key.type, &factory));
       column_comparators_.push_back(std::move(factory.res));
     }
@@ -716,18 +715,19 @@ class MultipleKeyComparator {
   }
 
   const std::vector<ResolvedSortKey>& sort_keys_;
-  const NullPlacement null_placement_;
   std::vector<std::unique_ptr<ColumnComparator<ResolvedSortKey>>> column_comparators_;
   Status status_;
 };
 
 struct ResolvedRecordBatchSortKey {
-  ResolvedRecordBatchSortKey(const std::shared_ptr<Array>& array, SortOrder order)
+  ResolvedRecordBatchSortKey(const std::shared_ptr<Array>& array, SortOrder order,
+                             NullPlacement null_placement)
       : type(GetPhysicalType(array->type())),
         owned_array(GetPhysicalArray(*array, type)),
         array(*owned_array),
         order(order),
-        null_count(array->null_count()) {}
+        null_count(array->null_count()),
+        null_placement(null_placement) {}
 
   using LocationType = int64_t;
 
@@ -741,16 +741,18 @@ struct ResolvedRecordBatchSortKey {
   const Array& array;
   SortOrder order;
   int64_t null_count;
+  NullPlacement null_placement;
 };
 
 struct ResolvedTableSortKey {
   ResolvedTableSortKey(const std::shared_ptr<DataType>& type, ArrayVector chunks,
-                       SortOrder order, int64_t null_count)
+                       SortOrder order, int64_t null_count, NullPlacement null_placement)
       : type(GetPhysicalType(type)),
         owned_chunks(std::move(chunks)),
         chunks(GetArrayPointers(owned_chunks)),
         order(order),
-        null_count(null_count) {}
+        null_count(null_count),
+        null_placement(null_placement) {}
 
   using LocationType = ::arrow::internal::ChunkLocation;
 
@@ -777,7 +779,7 @@ struct ResolvedTableSortKey {
       }
 
       return ResolvedTableSortKey(f.type->GetSharedPtr(), std::move(chunks), f.order,
-                                  null_count);
+                                  null_count, f.null_placement);
     };
 
     return ::arrow::compute::internal::ResolveSortKeys<ResolvedTableSortKey>(
@@ -789,6 +791,7 @@ struct ResolvedTableSortKey {
   std::vector<const Array*> chunks;
   SortOrder order;
   int64_t null_count;
+  NullPlacement null_placement;
 };
 
 inline Result<std::shared_ptr<ArrayData>> MakeMutableUInt64Array(

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -1205,9 +1205,8 @@ TEST_F(TestRecordBatchSortIndices, NoNull) {
                                        ])");
 
   for (auto null_placement : AllNullPlacements()) {
-    SortOptions options(
-        {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)},
-        null_placement);
+    SortOptions options({SortKey("a", SortOrder::Ascending, null_placement),
+                         SortKey("b", SortOrder::Descending, null_placement)});
 
     AssertSortIndices(batch, options, "[3, 5, 1, 6, 4, 0, 2]");
   }
@@ -1230,9 +1229,11 @@ TEST_F(TestRecordBatchSortIndices, Null) {
   const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[5, 1, 4, 6, 2, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[0, 3, 5, 1, 4, 6, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[3, 0, 5, 1, 4, 2, 6]");
 }
 
@@ -1251,12 +1252,14 @@ TEST_F(TestRecordBatchSortIndices, NaN) {
                                        {"a": NaN,  "b": 5},
                                        {"a": 1,    "b": 5}
                                       ])");
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[3, 7, 1, 0, 2, 4, 6, 5]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[4, 6, 5, 3, 7, 1, 0, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[5, 4, 6, 3, 1, 7, 0, 2]");
 }
 
@@ -1275,12 +1278,14 @@ TEST_F(TestRecordBatchSortIndices, NaNAndNull) {
                                        {"a": NaN,  "b": 5},
                                        {"a": 1,    "b": 5}
                                       ])");
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 }
 
@@ -1299,12 +1304,14 @@ TEST_F(TestRecordBatchSortIndices, Boolean) {
                                        {"a": false,   "b": null},
                                        {"a": null,    "b": true}
                                        ])");
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[3, 1, 6, 2, 4, 0, 7, 5]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[7, 5, 3, 1, 6, 2, 4, 0]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[7, 5, 1, 6, 3, 0, 2, 4]");
 }
 
@@ -1322,12 +1329,15 @@ TEST_F(TestRecordBatchSortIndices, MoreTypes) {
                                        {"a": 2, "b": "05",   "c": "aaa"},
                                        {"a": 1, "b": "05",   "c": "bbb"}
                                        ])");
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending),
                                        SortKey("c", SortOrder::Ascending)};
 
   for (auto null_placement : AllNullPlacements()) {
-    SortOptions options(sort_keys, null_placement);
+    SortOptions options(sort_keys);
+    for (size_t i = 0; i < sort_keys.size(); i++) {
+      options.sort_keys[i].null_placement = null_placement;
+    }
     AssertSortIndices(batch, options, "[3, 5, 1, 4, 0, 2]");
   }
 }
@@ -1344,12 +1354,14 @@ TEST_F(TestRecordBatchSortIndices, Decimal) {
                                        {"a": "-12.3", "b": null},
                                        {"a": "-12.3", "b": "-45.67"}
                                        ])");
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[4, 3, 0, 2, 1]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[4, 3, 0, 2, 1]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[3, 4, 0, 2, 1]");
 }
 
@@ -1375,37 +1387,31 @@ TEST_F(TestRecordBatchSortIndices, NullType) {
     for (const auto order : AllOrders()) {
       // Uses radix sorter
       AssertSortIndices(batch,
-                        SortOptions(
-                            {
-                                SortKey("a", order),
-                                SortKey("i", order),
-                            },
-                            null_placement),
+                        SortOptions({
+                            SortKey("a", order, null_placement),
+                            SortKey("i", order, null_placement),
+                        }),
                         "[0, 1, 2, 3]");
       AssertSortIndices(batch,
-                        SortOptions(
-                            {
-                                SortKey("a", order),
-                                SortKey("b", SortOrder::Ascending),
-                                SortKey("i", order),
-                            },
-                            null_placement),
+                        SortOptions({
+                            SortKey("a", order, null_placement),
+                            SortKey("b", SortOrder::Ascending, null_placement),
+                            SortKey("i", order, null_placement),
+                        }),
                         "[2, 3, 0, 1]");
       // Uses multiple-key sorter
       AssertSortIndices(batch,
-                        SortOptions(
-                            {
-                                SortKey("a", order),
-                                SortKey("b", SortOrder::Ascending),
-                                SortKey("c", SortOrder::Ascending),
-                                SortKey("d", SortOrder::Ascending),
-                                SortKey("e", SortOrder::Ascending),
-                                SortKey("f", SortOrder::Ascending),
-                                SortKey("g", SortOrder::Ascending),
-                                SortKey("h", SortOrder::Ascending),
-                                SortKey("i", order),
-                            },
-                            null_placement),
+                        SortOptions({
+                            SortKey("a", order, null_placement),
+                            SortKey("b", SortOrder::Ascending, null_placement),
+                            SortKey("c", SortOrder::Ascending, null_placement),
+                            SortKey("d", SortOrder::Ascending, null_placement),
+                            SortKey("e", SortOrder::Ascending, null_placement),
+                            SortKey("f", SortOrder::Ascending, null_placement),
+                            SortKey("g", SortOrder::Ascending, null_placement),
+                            SortKey("h", SortOrder::Ascending, null_placement),
+                            SortKey("i", order),
+                        }),
                         "[2, 3, 0, 1]");
     }
   }
@@ -1428,14 +1434,16 @@ TEST_F(TestRecordBatchSortIndices, DuplicateSortKeys) {
                                        {"a": NaN,  "b": 5},
                                        {"a": 1,    "b": 5}
                                       ])");
-  const std::vector<SortKey> sort_keys{
+  std::vector<SortKey> sort_keys{
       SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending),
       SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Ascending),
       SortKey("a", SortOrder::Descending)};
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(batch, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(batch, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(batch, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 }
 
@@ -1447,16 +1455,19 @@ TEST_F(TestTableSortIndices, EmptyTable) {
       {field("a", uint8())},
       {field("b", uint32())},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
 
   auto table = TableFromJSON(schema, {"[]"});
   auto chunked_table = TableFromJSON(schema, {"[]", "[]"});
 
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[]");
   AssertSortIndices(chunked_table, options, "[]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[]");
+  AssertSortIndices(chunked_table, options, "[]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[]");
   AssertSortIndices(chunked_table, options, "[]");
 }
@@ -1467,7 +1478,7 @@ TEST_F(TestTableSortIndices, EmptySortKeys) {
       {field("b", uint32())},
   });
   const std::vector<SortKey> sort_keys{};
-  const SortOptions options(sort_keys, NullPlacement::AtEnd);
+  const SortOptions options(sort_keys);
 
   auto table = TableFromJSON(schema, {R"([{"a": null, "b": 5}])"});
   EXPECT_RAISES_WITH_MESSAGE_THAT(
@@ -1486,7 +1497,7 @@ TEST_F(TestTableSortIndices, Null) {
       {field("a", uint8())},
       {field("b", uint32())},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
   std::shared_ptr<Table> table;
 
@@ -1498,9 +1509,11 @@ TEST_F(TestTableSortIndices, Null) {
                                      {"a": 1,    "b": 5},
                                      {"a": 3,    "b": 5}
                                     ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[5, 1, 4, 6, 2, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 5, 1, 4, 6, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 5, 1, 4, 2, 6]");
 
   // Same data, several chunks
@@ -1513,9 +1526,12 @@ TEST_F(TestTableSortIndices, Null) {
                                      {"a": 1,    "b": 5},
                                      {"a": 3,    "b": 5}
                                     ])"});
-  options.null_placement = NullPlacement::AtEnd;
+  options.sort_keys[0].null_placement = NullPlacement::AtEnd;
+  options.sort_keys[1].null_placement = NullPlacement::AtEnd;
   AssertSortIndices(table, options, "[5, 1, 4, 6, 2, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 5, 1, 4, 6, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 5, 1, 4, 2, 6]");
 }
 
@@ -1524,7 +1540,7 @@ TEST_F(TestTableSortIndices, NaN) {
       {field("a", float32())},
       {field("b", float64())},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
   std::shared_ptr<Table> table;
 
@@ -1537,9 +1553,11 @@ TEST_F(TestTableSortIndices, NaN) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[3, 7, 1, 0, 2, 4, 6, 5]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[4, 6, 5, 3, 7, 1, 0, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[5, 4, 6, 3, 1, 7, 0, 2]");
 
   // Same data, several chunks
@@ -1553,9 +1571,12 @@ TEST_F(TestTableSortIndices, NaN) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  options.null_placement = NullPlacement::AtEnd;
+  options.sort_keys[0].null_placement = NullPlacement::AtEnd;
+  options.sort_keys[1].null_placement = NullPlacement::AtEnd;
   AssertSortIndices(table, options, "[3, 7, 1, 0, 2, 4, 6, 5]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[4, 6, 5, 3, 7, 1, 0, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[5, 4, 6, 3, 1, 7, 0, 2]");
 }
 
@@ -1564,7 +1585,7 @@ TEST_F(TestTableSortIndices, NaNAndNull) {
       {field("a", float32())},
       {field("b", float64())},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
   std::shared_ptr<Table> table;
 
@@ -1577,9 +1598,11 @@ TEST_F(TestTableSortIndices, NaNAndNull) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 
   // Same data, several chunks
@@ -1593,9 +1616,12 @@ TEST_F(TestTableSortIndices, NaNAndNull) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  options.null_placement = NullPlacement::AtEnd;
+  options.sort_keys[0].null_placement = NullPlacement::AtEnd;
+  options.sort_keys[1].null_placement = NullPlacement::AtEnd;
   AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 }
 
@@ -1604,8 +1630,8 @@ TEST_F(TestTableSortIndices, Boolean) {
       {field("a", boolean())},
       {field("b", boolean())},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
 
   auto table = TableFromJSON(schema, {R"([{"a": true,    "b": null},
                                           {"a": false,   "b": null},
@@ -1617,9 +1643,11 @@ TEST_F(TestTableSortIndices, Boolean) {
                                           {"a": false,   "b": null},
                                           {"a": null,    "b": true}
                                          ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[3, 1, 6, 2, 4, 0, 7, 5]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[7, 5, 3, 1, 6, 2, 4, 0]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[7, 5, 1, 6, 3, 0, 2, 4]");
 }
 
@@ -1628,8 +1656,8 @@ TEST_F(TestTableSortIndices, BinaryLike) {
       {field("a", large_utf8())},
       {field("b", fixed_size_binary(3))},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Descending),
-                                       SortKey("b", SortOrder::Ascending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Descending),
+                                 SortKey("b", SortOrder::Ascending)};
 
   auto table = TableFromJSON(schema, {R"([{"a": "one", "b": null},
                                           {"a": "two", "b": "aaa"},
@@ -1641,9 +1669,10 @@ TEST_F(TestTableSortIndices, BinaryLike) {
                                           {"a": "three", "b": "bbb"},
                                           {"a": "four", "b": "aaa"}
                                          ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[1, 5, 2, 6, 4, 0, 7, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[1, 5, 2, 6, 0, 4, 7, 3]");
 }
 
@@ -1652,8 +1681,8 @@ TEST_F(TestTableSortIndices, Decimal) {
       {field("a", decimal128(3, 1))},
       {field("b", decimal256(4, 2))},
   });
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
-                                       SortKey("b", SortOrder::Descending)};
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+                                 SortKey("b", SortOrder::Descending)};
 
   auto table = TableFromJSON(schema, {R"([{"a": "12.3", "b": "12.34"},
                                           {"a": "45.6", "b": "12.34"},
@@ -1662,9 +1691,11 @@ TEST_F(TestTableSortIndices, Decimal) {
                                       R"([{"a": "-12.3", "b": null},
                                           {"a": "-12.3", "b": "-45.67"}
                                           ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[4, 3, 0, 2, 1]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[4, 3, 0, 2, 1]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 4, 0, 2, 1]");
 }
 
@@ -1687,21 +1718,17 @@ TEST_F(TestTableSortIndices, NullType) {
   for (const auto null_placement : AllNullPlacements()) {
     for (const auto order : AllOrders()) {
       AssertSortIndices(table,
-                        SortOptions(
-                            {
-                                SortKey("a", order),
-                                SortKey("d", order),
-                            },
-                            null_placement),
+                        SortOptions({
+                            SortKey("a", order, null_placement),
+                            SortKey("d", order, null_placement),
+                        }),
                         "[0, 1, 2, 3]");
       AssertSortIndices(table,
-                        SortOptions(
-                            {
-                                SortKey("a", order),
-                                SortKey("b", SortOrder::Ascending),
-                                SortKey("d", order),
-                            },
-                            null_placement),
+                        SortOptions({
+                            SortKey("a", order, null_placement),
+                            SortKey("b", SortOrder::Ascending, null_placement),
+                            SortKey("d", order, null_placement),
+                        }),
                         "[2, 3, 0, 1]");
     }
   }
@@ -1714,7 +1741,7 @@ TEST_F(TestTableSortIndices, DuplicateSortKeys) {
       {field("a", float32())},
       {field("b", float64())},
   });
-  const std::vector<SortKey> sort_keys{
+  std::vector<SortKey> sort_keys{
       SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending),
       SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Ascending),
       SortKey("a", SortOrder::Descending)};
@@ -1730,9 +1757,11 @@ TEST_F(TestTableSortIndices, DuplicateSortKeys) {
                                      {"a": NaN,  "b": 5},
                                      {"a": 1,    "b": 5}
                                     ])"});
-  SortOptions options(sort_keys, NullPlacement::AtEnd);
+  SortOptions options(sort_keys);
   AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 }
 
@@ -1752,13 +1781,17 @@ TEST_F(TestTableSortIndices, HeterogenousChunking) {
   SortOptions options(
       {SortKey("a", SortOrder::Ascending), SortKey("b", SortOrder::Descending)});
   AssertSortIndices(table, options, "[7, 1, 2, 6, 5, 4, 0, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[0, 3, 6, 5, 4, 7, 1, 2]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 0, 4, 5, 6, 7, 1, 2]");
 
   options = SortOptions(
       {SortKey("b", SortOrder::Ascending), SortKey("a", SortOrder::Descending)});
   AssertSortIndices(table, options, "[1, 7, 6, 0, 5, 2, 4, 3]");
-  options.null_placement = NullPlacement::AtStart;
+  options.sort_keys[0].null_placement = NullPlacement::AtStart;
+  AssertSortIndices(table, options, "[2, 4, 3, 5, 1, 7, 6, 0]");
+  options.sort_keys[1].null_placement = NullPlacement::AtStart;
   AssertSortIndices(table, options, "[3, 4, 2, 5, 1, 0, 6, 7]");
 }
 
@@ -1772,7 +1805,7 @@ TYPED_TEST_SUITE(TestTableSortIndicesForTemporal, TemporalArrowTypes);
 
 TYPED_TEST(TestTableSortIndicesForTemporal, NoNull) {
   auto type = this->GetType();
-  const std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
+  std::vector<SortKey> sort_keys{SortKey("a", SortOrder::Ascending),
                                        SortKey("b", SortOrder::Descending)};
   auto table = TableFromJSON(schema({
                                  {field("a", type)},
@@ -1788,7 +1821,10 @@ TYPED_TEST(TestTableSortIndicesForTemporal, NoNull) {
                                   {"a": 1, "b": 2}
                                  ])"});
   for (auto null_placement : AllNullPlacements()) {
-    SortOptions options(sort_keys, null_placement);
+    SortOptions options(sort_keys);
+    for (size_t i = 0; i < sort_keys.size(); i++) {
+      options.sort_keys[i].null_placement = null_placement;
+    }
     AssertSortIndices(table, options, "[0, 6, 1, 4, 7, 3, 2, 5]");
   }
 }
@@ -1861,12 +1897,12 @@ class TestTableSortIndicesRandom : public testing::TestWithParam<RandomParam> {
         DCHECK(!sort_key.target.IsNested());
 
         if (auto name = sort_key.target.name()) {
-          sort_columns_.emplace_back(table.GetColumnByName(*name).get(), sort_key.order);
+          sort_columns_.emplace_back(table.GetColumnByName(*name).get(), sort_key);
           continue;
         }
 
         auto index = sort_key.target.field_path()->indices()[0];
-        sort_columns_.emplace_back(table.column(index).get(), sort_key.order);
+        sort_columns_.emplace_back(table.column(index).get(), sort_key);
       }
     }
 
@@ -1874,7 +1910,7 @@ class TestTableSortIndicesRandom : public testing::TestWithParam<RandomParam> {
     // false otherwise.
     bool operator()(uint64_t lhs, uint64_t rhs) {
       for (const auto& pair : sort_columns_) {
-        ColumnComparator comparator(pair.second, options_.null_placement);
+        ColumnComparator comparator(pair.second.order, pair.second.null_placement);
         const auto& chunked_array = *pair.first;
         int64_t lhs_index = 0, rhs_index = 0;
         const Array* lhs_array = FindTargetArray(chunked_array, lhs, &lhs_index);
@@ -1903,7 +1939,7 @@ class TestTableSortIndicesRandom : public testing::TestWithParam<RandomParam> {
     }
 
     const SortOptions& options_;
-    std::vector<std::pair<const ChunkedArray*, SortOrder>> sort_columns_;
+    std::vector<std::pair<const ChunkedArray*, SortKey>> sort_columns_;
   };
 
  public:
@@ -2064,7 +2100,9 @@ TEST_P(TestTableSortIndicesRandom, Sort) {
     auto table = Table::Make(schema, std::move(columns));
     for (auto null_placement : AllNullPlacements()) {
       ARROW_SCOPED_TRACE("null_placement = ", null_placement);
-      options.null_placement = null_placement;
+      for (auto& sort_key : sort_keys) {
+        sort_key.null_placement = null_placement;
+      }
       ASSERT_OK_AND_ASSIGN(auto offsets, SortIndices(Datum(*table), options));
       Validate(*table, options, *checked_pointer_cast<UInt64Array>(offsets));
     }
@@ -2083,7 +2121,9 @@ TEST_P(TestTableSortIndicesRandom, Sort) {
 
   for (auto null_placement : AllNullPlacements()) {
     ARROW_SCOPED_TRACE("null_placement = ", null_placement);
-    options.null_placement = null_placement;
+    for (auto& sort_key : sort_keys) {
+      sort_key.null_placement = null_placement;
+    }
     ASSERT_OK_AND_ASSIGN(auto offsets, SortIndices(Datum(batch), options));
     Validate(*table, options, *checked_pointer_cast<UInt64Array>(offsets));
   }
@@ -2173,18 +2213,21 @@ class TestNestedSortIndices : public ::testing::Test {
     std::vector<SortKey> sort_keys = {SortKey(FieldRef("a", "a"), SortOrder::Ascending),
                                       SortKey(FieldRef("a", "b"), SortOrder::Descending)};
 
-    SortOptions options(sort_keys, NullPlacement::AtEnd);
+    SortOptions options(sort_keys);
     AssertSortIndices(datum, options, "[7, 6, 3, 4, 0, 2, 1, 8, 5]");
-    options.null_placement = NullPlacement::AtStart;
+    options.sort_keys[0].null_placement = NullPlacement::AtStart;
+    options.sort_keys[1].null_placement = NullPlacement::AtStart;
     AssertSortIndices(datum, options, "[5, 2, 1, 8, 3, 7, 6, 0, 4]");
 
     // Implementations may have an optimized path for cases with one sort key.
     // Additionally, this key references a struct containing another struct, which should
     // work recursively
     options.sort_keys = {SortKey(FieldRef("a"), SortOrder::Ascending)};
-    options.null_placement = NullPlacement::AtEnd;
+    options.sort_keys[0].null_placement = NullPlacement::AtEnd;
+    options.sort_keys[1].null_placement = NullPlacement::AtEnd;
     AssertSortIndices(datum, options, "[6, 7, 3, 4, 0, 8, 1, 2, 5]");
-    options.null_placement = NullPlacement::AtStart;
+    options.sort_keys[0].null_placement = NullPlacement::AtStart;
+    options.sort_keys[1].null_placement = NullPlacement::AtStart;
     AssertSortIndices(datum, options, "[5, 8, 1, 2, 3, 6, 7, 0, 4]");
   }
 

--- a/cpp/src/arrow/compute/ordering.h
+++ b/cpp/src/arrow/compute/ordering.h
@@ -46,8 +46,11 @@ enum class NullPlacement {
 /// \brief One sort key for PartitionNthIndices (TODO) and SortIndices
 class ARROW_EXPORT SortKey : public util::EqualityComparable<SortKey> {
  public:
-  explicit SortKey(FieldRef target, SortOrder order = SortOrder::Ascending)
-      : target(std::move(target)), order(order) {}
+  explicit SortKey(FieldRef target, SortOrder order = SortOrder::Ascending,
+                   NullPlacement null_placement = NullPlacement::AtEnd)
+      : target(std::move(target)), order(order), null_placement(null_placement) {}
+  explicit SortKey(FieldRef target, NullPlacement null_placement)
+      : SortKey(std::move(target), SortOrder::Ascending, null_placement) {}
 
   bool Equals(const SortKey& other) const;
   std::string ToString() const;
@@ -56,13 +59,13 @@ class ARROW_EXPORT SortKey : public util::EqualityComparable<SortKey> {
   FieldRef target;
   /// How to order by this sort key.
   SortOrder order;
+  /// Whether nulls and NaNs are placed at the start or at the end
+  NullPlacement null_placement;
 };
 
 class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
  public:
-  Ordering(std::vector<SortKey> sort_keys,
-           NullPlacement null_placement = NullPlacement::AtStart)
-      : sort_keys_(std::move(sort_keys)), null_placement_(null_placement) {}
+  Ordering(std::vector<SortKey> sort_keys) : sort_keys_(std::move(sort_keys)) {}
   /// true if data ordered by other is also ordered by this
   ///
   /// For example, if data is ordered by [a, b, c] then it is also ordered
@@ -91,7 +94,6 @@ class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
   bool is_unordered() const { return !is_implicit_ && sort_keys_.empty(); }
 
   const std::vector<SortKey>& sort_keys() const { return sort_keys_; }
-  NullPlacement null_placement() const { return null_placement_; }
 
   static const Ordering& Implicit() {
     static const Ordering kImplicit(true);
@@ -107,12 +109,9 @@ class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
   }
 
  private:
-  explicit Ordering(bool is_implicit)
-      : null_placement_(NullPlacement::AtStart), is_implicit_(is_implicit) {}
+  explicit Ordering(bool is_implicit) : is_implicit_(is_implicit) {}
   /// Column key(s) to order by and how to order by these sort keys.
   std::vector<SortKey> sort_keys_;
-  /// Whether nulls and NaNs are placed at the start or at the end
-  NullPlacement null_placement_;
   bool is_implicit_ = false;
 };
 

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -797,21 +797,10 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
 
       std::vector<compute::SortKey> sort_keys;
       sort_keys.reserve(sort.sorts_size());
-      // Substrait allows null placement to differ for each field.  Acero expects it to
-      // be consistent across all fields.  So we grab the null placement from the first
-      // key and verify all other keys have the same null placement
-      std::optional<SortBehavior> sample_sort_behavior;
+      // Substrait allows null placement to differ for each field.  
       for (const auto& sort : sort.sorts()) {
         ARROW_ASSIGN_OR_RAISE(SortBehavior sort_behavior,
                               SortBehavior::Make(sort.direction()));
-        if (sample_sort_behavior) {
-          if (sample_sort_behavior->null_placement != sort_behavior.null_placement) {
-            return Status::NotImplemented(
-                "substrait::SortRel with ordering with mixed null placement");
-          }
-        } else {
-          sample_sort_behavior = sort_behavior;
-        }
         if (sort.sort_kind_case() != substrait::SortField::SortKindCase::kDirection) {
           return Status::NotImplemented("substrait::SortRel with custom sort function");
         }
@@ -819,18 +808,16 @@ Result<DeclarationInfo> FromProto(const substrait::Rel& rel, const ExtensionSet&
                               FromProto(sort.expr(), ext_set, conversion_options));
         const FieldRef* field_ref = expr.field_ref();
         if (field_ref) {
-          sort_keys.push_back(compute::SortKey(*field_ref, sort_behavior.sort_order));
+          sort_keys.push_back(compute::SortKey(*field_ref, sort_behavior.sort_order, sort_behavior.null_placement));
         } else {
           return Status::Invalid("Sort key expressions must be a direct reference.");
         }
       }
 
-      DCHECK(sample_sort_behavior.has_value());
       acero::Declaration sort_dec{
           "order_by",
           {input.declaration},
-          acero::OrderByNodeOptions(compute::Ordering(
-              std::move(sort_keys), sample_sort_behavior->null_placement))};
+          acero::OrderByNodeOptions(compute::Ordering(std::move(sort_keys)))};
 
       DeclarationInfo sort_declaration{std::move(sort_dec), input.output_schema};
       return ProcessEmit(sort, std::move(sort_declaration),

--- a/cpp/src/arrow/engine/substrait/serde_test.cc
+++ b/cpp/src/arrow/engine/substrait/serde_test.cc
@@ -5378,8 +5378,8 @@ TEST(Substrait, SortAndFetch) {
 }
 
 TEST(Substrait, MixedSort) {
-  // Substrait allows two sort keys with differing direction but Acero
-  // does not.  We should detect this and reject it.
+  // Substrait allows two sort keys with differing direction and 
+  // acero is now supported.
   std::string substrait_json = R"({
   "version": {
     "major_number": 9999,
@@ -5474,10 +5474,9 @@ TEST(Substrait, MixedSort) {
   ConversionOptions conversion_options;
   conversion_options.named_table_provider = std::move(table_provider);
 
-  ASSERT_THAT(
-      DeserializePlan(*buf, /*registry=*/nullptr, /*ext_set_out=*/nullptr,
-                      conversion_options),
-      Raises(StatusCode::NotImplemented, testing::HasSubstr("mixed null placement")));
+  ASSERT_OK_AND_ASSIGN(
+      auto plan_info, DeserializePlan(*buf, /*registry=*/nullptr, /*ext_set_out=*/nullptr,
+                                      conversion_options));
 }
 
 TEST(Substrait, PlanWithExtension) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->